### PR TITLE
oauth login fix

### DIFF
--- a/client_server/back_b/models/index.js
+++ b/client_server/back_b/models/index.js
@@ -5,8 +5,8 @@ const config = require(__dirname + '/../config/config.json')[env];
 
 const sequelize = new Sequelize(config.database, config.username, config.password, config);
 
-const Account = require('./models/Account')(sequelize, DataTypes);
-const UserInfo = require('./models/UserInfo')(sequelize, DataTypes);
+const Account = require('./models/account')(sequelize, DataTypes);
+const UserInfo = require('./models/userInfo')(sequelize, DataTypes);
 
 const auth = require('./Auth')(sequelize, DataTypes);
 

--- a/client_server/back_b/router/Oauth.js
+++ b/client_server/back_b/router/Oauth.js
@@ -22,9 +22,13 @@ router.get('/DIDLogin', async (req, res) => {
 });
 
 router.get('/getCode', async (req, res) => {
-    const { email, hash } = req.query;
+    const { email, hash1 } = req.query;
     const url = 'http://localhost:8000/oauth/login/codeAuthorize';
 
+    const hash = hash1.replace(/ /g, '+');
+    console.log('-----------');
+    console.log(hash);
+    console.log('--------------');
     const Data = {
         grant_type: 'authorization_code',
         restAPI: Otp.clientId,
@@ -48,12 +52,14 @@ router.get('/getCode', async (req, res) => {
         const url = 'http://localhost:8000/oauth/login/codeAuthorize2';
         const Header = {
             headers: {
-                Authorization: `Bearer ${access_token}`,
+                Authorization: access_token,
             },
         };
 
         const response = await axios.get(url, Header);
         const { VP, hash } = response.data;
+
+        console.log(VP);
 
         const vpCookie = filterNull(VP);
 

--- a/oAuth_Server/back/router/app/app.ts
+++ b/oAuth_Server/back/router/app/app.ts
@@ -240,6 +240,8 @@ router.post('/userdidregister', async (req, res) => {
 
         const rawVp = await getUserinfo(restAPI, hash)
 
+        console.log(rawVp)
+
         const refinedVP = refineVP(rawVp)
 
         console.log(email)


### PR DESCRIPTION
에러 원인 : oauth 서버의 /authorize 라우터에서 local backend의 getCode로 갈때

원인은 알 수 없지만 '+' 문자가 ' '로 치환이 됩니다.

이게 +만 그런건지 잠재적인 다른 이슈가 터질지는 모르겠으니 일단 미봉책으로 빈 ' '를 다시 '+'로 바꿔주는 코드를 추가해보니

잘 되는 것 같습니다.

시간이 될 때 보강해두도록 하겠습니다.

제가 처음 테스트했던 아이디는 재수없게도 하필 hash 했을때 '+'가 없는 결과물이 나와서 문제가 없었던 것 같습니다..